### PR TITLE
Fix unsealing mocked fhe ops sealed outputs

### DIFF
--- a/packages/fhenix-hardhat-plugin/src/FhenixHardhatRuntimeEnvironment.ts
+++ b/packages/fhenix-hardhat-plugin/src/FhenixHardhatRuntimeEnvironment.ts
@@ -152,7 +152,7 @@ export class FhenixHardhatRuntimeEnvironment extends FhenixClient {
   public unseal(contractAddress: string, ciphertext: string): bigint {
     // console.log(`ct: ${ciphertext}`);
     if (this.network === "hardhat") {
-      return BigInt(ciphertext);
+      return uint8ArrayToBigint(ciphertext);
     } else {
       return super.unseal(contractAddress, ciphertext);
     }
@@ -211,6 +211,19 @@ export class MockProvider {
 //   }
 //   return u8;
 // }
+
+function uint8ArrayToBigint(uint8ArrayStr: string): bigint {
+  const byteArray = new Uint8Array(
+    uint8ArrayStr.split("").map((c) => c.charCodeAt(0)),
+  );
+
+  let result = BigInt(0);
+  for (const byteArrayItem of byteArray) {
+    result = (result << BigInt(8)) + BigInt(byteArrayItem);
+  }
+
+  return result;
+}
 
 function bigintToUint8Array(bigNum: bigint): Uint8Array {
   const byteLength = 32;


### PR DESCRIPTION
```
SyntaxError: Cannot convert to a BigInt
```

When `MockFheOps.sol` is injected, the output type of sealed data is in the form
```
"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\n"
```

Which throws an error when casted to a bigint

Attempt number 3 😓 