### PR TITLE
Clean deployments/localfhenix directory on localfhenix:start

### DIFF
--- a/packages/fhenix-hardhat-docker/src/const.ts
+++ b/packages/fhenix-hardhat-docker/src/const.ts
@@ -6,4 +6,5 @@ export const TASK_FHENIX_DOCKER_START = "localfhenix:start";
 export const TASK_FHENIX_DOCKER_STOP = "localfhenix:stop";
 export const LOCALFHENIX_CONTAINER_NAME = container_name;
 export const SUBTASK_FHENIX_DOCKER_PULL = "localfhenix:pull";
-export const SUBTASK_FHENIX_DOCKER_CLEAN_DEPLOYMENTS = "localfhenix:cleanDeployments";
+export const SUBTASK_FHENIX_DOCKER_CLEAN_DEPLOYMENTS =
+  "localfhenix:cleanDeployments";

--- a/packages/fhenix-hardhat-docker/src/const.ts
+++ b/packages/fhenix-hardhat-docker/src/const.ts
@@ -6,3 +6,4 @@ export const TASK_FHENIX_DOCKER_START = "localfhenix:start";
 export const TASK_FHENIX_DOCKER_STOP = "localfhenix:stop";
 export const LOCALFHENIX_CONTAINER_NAME = container_name;
 export const SUBTASK_FHENIX_DOCKER_PULL = "localfhenix:pull";
+export const SUBTASK_FHENIX_DOCKER_CLEAN_DEPLOYMENTS = "localfhenix:cleanDeployments";

--- a/packages/fhenix-hardhat-docker/src/env.ts
+++ b/packages/fhenix-hardhat-docker/src/env.ts
@@ -1,17 +1,17 @@
 import chalk from "chalk";
-import fs from 'fs';
-import path from 'path';
+import fs from "fs";
+import path from "path";
 
 export const cleanDeployments = (): void => {
   console.log(chalk.green("Cleaning deployments.."));
 
   // Get the current working directory (root of the project that imported this package)
   const cwd = process.cwd();
-  const deploymentsPath = path.join(cwd, 'deployments');
+  const deploymentsPath = path.join(cwd, "deployments");
 
   if (fs.existsSync(deploymentsPath)) {
     fs.rmSync(deploymentsPath, { recursive: true, force: true });
-    console.log(chalk.green('Successfully cleaned deployments directory'));
+    console.log(chalk.green("Successfully cleaned deployments directory"));
   } else {
     console.log(chalk.yellow(`No deployments found in ${deploymentsPath}`));
   }

--- a/packages/fhenix-hardhat-docker/src/env.ts
+++ b/packages/fhenix-hardhat-docker/src/env.ts
@@ -7,7 +7,7 @@ export const cleanDeployments = (): void => {
 
   // Get the current working directory (root of the project that imported this package)
   const cwd = process.cwd();
-  const deploymentsPath = path.join(cwd, "deployments");
+  const deploymentsPath = path.join(cwd, "deployments/localfhenix");
 
   if (fs.existsSync(deploymentsPath)) {
     fs.rmSync(deploymentsPath, { recursive: true, force: true });

--- a/packages/fhenix-hardhat-docker/src/env.ts
+++ b/packages/fhenix-hardhat-docker/src/env.ts
@@ -1,0 +1,18 @@
+import chalk from "chalk";
+import fs from 'fs';
+import path from 'path';
+
+export const cleanDeployments = (): void => {
+  console.log(chalk.green("Cleaning deployments.."));
+
+  // Get the current working directory (root of the project that imported this package)
+  const cwd = process.cwd();
+  const deploymentsPath = path.join(cwd, 'deployments');
+
+  if (fs.existsSync(deploymentsPath)) {
+    fs.rmSync(deploymentsPath, { recursive: true, force: true });
+    console.log(chalk.green('Successfully cleaned deployments directory'));
+  } else {
+    console.log(chalk.yellow(`No deployments found in ${deploymentsPath}`));
+  }
+};

--- a/packages/fhenix-hardhat-docker/src/index.ts
+++ b/packages/fhenix-hardhat-docker/src/index.ts
@@ -6,6 +6,7 @@ import {
   FHENIX_DEFAULT_IMAGE,
   FHENIX_DEFAULT_IMAGE_ARM,
   LOCALFHENIX_CONTAINER_NAME,
+  SUBTASK_FHENIX_DOCKER_CLEAN_DEPLOYMENTS,
   SUBTASK_FHENIX_DOCKER_PULL,
   TASK_FHENIX_DOCKER_START,
   TASK_FHENIX_DOCKER_STOP,
@@ -16,6 +17,7 @@ import {
   runLocalFhenixSeparateProcess,
   stopLocalFhenix,
 } from "./docker";
+import { cleanDeployments } from "./env";
 
 task(TASK_FHENIX_DOCKER_STOP, "Stops a LocalFhenix node").setAction(
   async () => {
@@ -28,6 +30,11 @@ subtask(SUBTASK_FHENIX_DOCKER_PULL, "Pulls the latest LocalFhenix image")
   .addOptionalParam("image", "Specified docker image to pull", undefined)
   .setAction(async ({ image }: { image: string }) => {
     pullDockerContainer(image);
+  });
+
+subtask(SUBTASK_FHENIX_DOCKER_CLEAN_DEPLOYMENTS, "Cleans existing contract deployments")
+  .setAction(async () => {
+    cleanDeployments();
   });
 
 // Main task of the plugin. It starts the server and listens for requests.
@@ -52,6 +59,7 @@ task(TASK_FHENIX_DOCKER_START, "Starts a LocalFhenix node")
   )
   .addOptionalParam("image", `Fhenix image to use`, undefined, types.string)
   // .addOptionalParam('log', 'Log filter level (error, warn, info, debug) - default: info', undefined, types.string)
+  .addOptionalParam("clean", `Clean previous deployments`, false, types.boolean)
   .setAction(
     async (
       {
@@ -59,12 +67,14 @@ task(TASK_FHENIX_DOCKER_START, "Starts a LocalFhenix node")
         ws,
         faucet,
         image,
+        clean,
       }: // log,
       {
         rpc: number;
         ws: number;
         faucet: number;
         image: string;
+        clean: boolean;
         // log: string;
       },
       { run },
@@ -86,5 +96,9 @@ task(TASK_FHENIX_DOCKER_START, "Starts a LocalFhenix node")
       console.info(
         chalk.green(`Started LocalFhenix successfully at 127.0.0.1:${rpc}`),
       );
+
+      if (clean) {
+        await run(SUBTASK_FHENIX_DOCKER_CLEAN_DEPLOYMENTS);
+      }
     },
   );

--- a/packages/fhenix-hardhat-docker/src/index.ts
+++ b/packages/fhenix-hardhat-docker/src/index.ts
@@ -32,10 +32,12 @@ subtask(SUBTASK_FHENIX_DOCKER_PULL, "Pulls the latest LocalFhenix image")
     pullDockerContainer(image);
   });
 
-subtask(SUBTASK_FHENIX_DOCKER_CLEAN_DEPLOYMENTS, "Cleans existing contract deployments")
-  .setAction(async () => {
-    cleanDeployments();
-  });
+subtask(
+  SUBTASK_FHENIX_DOCKER_CLEAN_DEPLOYMENTS,
+  "Cleans existing contract deployments",
+).setAction(async () => {
+  cleanDeployments();
+});
 
 // Main task of the plugin. It starts the server and listens for requests.
 task(TASK_FHENIX_DOCKER_START, "Starts a LocalFhenix node")

--- a/packages/fhenix-hardhat-docker/test/project.test.ts
+++ b/packages/fhenix-hardhat-docker/test/project.test.ts
@@ -46,5 +46,31 @@ describe("Fhenix Docker Tests", function () {
         throw new Error("Server did not stop");
       }
     });
+
+    it("Should clean deployments when clean flag is set", async function () {
+      // Create a test deployment file/directory
+      const fs = require('fs');
+      const path = require('path');
+      const deploymentsPath = path.join(process.cwd(), 'deployments');
+      
+      if (!fs.existsSync(deploymentsPath)) {
+        fs.mkdirSync(deploymentsPath);
+        fs.writeFileSync(path.join(deploymentsPath, 'test.json'), '{}');
+      }
+
+      // Start server with clean flag
+      await this.hre.run(TASK_FHENIX_DOCKER_START, { clean: true });
+
+      // Verify deployments directory was cleaned
+      const deploymentsExist = fs.existsSync(deploymentsPath);
+      if (deploymentsExist) {
+        // Clean up deployments directory if test fails
+        fs.rmSync(deploymentsPath, { recursive: true, force: true });
+        throw new Error("Deployments directory still exists");
+      }
+
+      // Clean up
+      await this.hre.run(TASK_FHENIX_DOCKER_STOP);
+    });
   });
 });

--- a/packages/fhenix-hardhat-docker/test/project.test.ts
+++ b/packages/fhenix-hardhat-docker/test/project.test.ts
@@ -4,6 +4,8 @@ import {
   TASK_FHENIX_DOCKER_STOP,
 } from "../src/const";
 import { isContainerRunning, stopLocalFhenix } from "../src/docker";
+import fs from "fs";
+import path from "path";
 
 import { useEnvironment } from "./helpers";
 
@@ -49,13 +51,11 @@ describe("Fhenix Docker Tests", function () {
 
     it("Should clean deployments when clean flag is set", async function () {
       // Create a test deployment file/directory
-      const fs = require('fs');
-      const path = require('path');
-      const deploymentsPath = path.join(process.cwd(), 'deployments');
-      
+      const deploymentsPath = path.join(process.cwd(), "deployments");
+
       if (!fs.existsSync(deploymentsPath)) {
         fs.mkdirSync(deploymentsPath);
-        fs.writeFileSync(path.join(deploymentsPath, 'test.json'), '{}');
+        fs.writeFileSync(path.join(deploymentsPath, "test.json"), "{}");
       }
 
       // Start server with clean flag

--- a/packages/fhenix-hardhat-docker/test/project.test.ts
+++ b/packages/fhenix-hardhat-docker/test/project.test.ts
@@ -51,26 +51,58 @@ describe("Fhenix Docker Tests", function () {
 
     it("Should clean deployments when clean flag is set", async function () {
       // Create a test deployment file/directory
-      const deploymentsPath = path.join(process.cwd(), "deployments");
+      const deploymentsPath = path.join(process.cwd(), "deployments/localfhenix");
 
       if (!fs.existsSync(deploymentsPath)) {
-        fs.mkdirSync(deploymentsPath);
+        fs.mkdirSync(deploymentsPath, { recursive: true });
         fs.writeFileSync(path.join(deploymentsPath, "test.json"), "{}");
       }
 
-      // Start server with clean flag
-      await this.hre.run(TASK_FHENIX_DOCKER_START, { clean: true });
+      try {
+        // Start server with clean flag
+        await this.hre.run(TASK_FHENIX_DOCKER_START, { clean: true });
 
-      // Verify deployments directory was cleaned
-      const deploymentsExist = fs.existsSync(deploymentsPath);
-      if (deploymentsExist) {
-        // Clean up deployments directory if test fails
-        fs.rmSync(deploymentsPath, { recursive: true, force: true });
-        throw new Error("Deployments directory still exists");
+        // Verify deployments directory was cleaned
+        const deploymentsExist = fs.existsSync(deploymentsPath);
+        if (deploymentsExist) {
+          throw new Error("Deployments directory still exists");
+        }
+      } finally {
+        // Cleanup
+        const deploymentsRootPath = path.join(process.cwd(), "deployments");
+        if (fs.existsSync(deploymentsRootPath)) {
+          fs.rmSync(deploymentsRootPath, { recursive: true, force: true });
+        }
+        await this.hre.run(TASK_FHENIX_DOCKER_STOP);
+      }
+    });
+
+    it("Should not clean deployments when clean flag is not set", async function () {
+      // Create a test deployment file/directory
+      const deploymentsPath = path.join(process.cwd(), "deployments/localfhenix");
+
+      if (!fs.existsSync(deploymentsPath)) {
+        fs.mkdirSync(deploymentsPath, { recursive: true });
+        fs.writeFileSync(path.join(deploymentsPath, "test.json"), "{}");
       }
 
-      // Clean up
-      await this.hre.run(TASK_FHENIX_DOCKER_STOP);
+      try {
+        // Start server without clean flag
+        await this.hre.run(TASK_FHENIX_DOCKER_START);
+
+        // Verify deployments directory still exists
+        const deploymentsExist = fs.existsSync(deploymentsPath);
+        if (!deploymentsExist) {
+          throw new Error("Deployments directory was unexpectedly removed");
+        }
+      } finally {
+        // Cleanup
+        const deploymentsRootPath = path.join(process.cwd(), "deployments");
+        if (fs.existsSync(deploymentsRootPath)) {
+          fs.rmSync(deploymentsRootPath, { recursive: true, force: true });
+        }
+        await this.hre.run(TASK_FHENIX_DOCKER_STOP);
+      }
     });
   });
 });


### PR DESCRIPTION
* Defines a new subtask for localfhenix:start
* Add as an optional argument for localfhenix:start, e.g. `localfhenix:start --clean`

closes #5 
1658705311