### PR TITLE
`fhenixsdk.initializeWithHHSigner` fixes

### DIFF
--- a/packages/fhenix-hardhat-plugin/mocha-fixtures.mjs
+++ b/packages/fhenix-hardhat-plugin/mocha-fixtures.mjs
@@ -8,7 +8,7 @@ const execPromise = util.promisify(exec);
 const CONTAINER_NAME = "fhenixjs-test-env";
 
 async function runDockerContainerAsync() {
-  const imageName = "ghcr.io/fhenixprotocol/nitro/localfhenix:v0.3.0-alpha.1";
+  const imageName = "ghcr.io/fhenixprotocol/localfhenix:v0.3.2";
 
   const ports = "-p 8545:8547 -p 5000:3000";
 

--- a/packages/fhenix-hardhat-plugin/mocha-fixtures.mjs
+++ b/packages/fhenix-hardhat-plugin/mocha-fixtures.mjs
@@ -1,0 +1,87 @@
+import util from "util";
+import { JsonRpcProvider } from "ethers";
+import { exec } from "child_process";
+
+const TEST_ENDPOINT_URL = process.env.TEST_ENDPOINT || "http://localhost:8545";
+
+const execPromise = util.promisify(exec);
+const CONTAINER_NAME = "fhenixjs-test-env";
+
+async function runDockerContainerAsync() {
+  const imageName = "ghcr.io/fhenixprotocol/nitro/localfhenix:v0.3.0-alpha.1";
+
+  const ports = "-p 8545:8547 -p 5000:3000";
+
+  const removePrevious = `docker kill ${CONTAINER_NAME}`;
+
+  const command = `docker run --rm --env FHEOS_SECURITY_ZONES=2 --name ${CONTAINER_NAME} ${ports} -d ${imageName}`;
+
+  try {
+    try {
+      await execPromise(removePrevious);
+    } catch (_) {}
+    const result = await execPromise(command);
+    // console.log(result.stdout);
+    // console.error(result.stderr);
+  } catch (error) {
+    console.error(error);
+    throw new Error("Failed to start docker container");
+  }
+}
+
+async function killDockerContainerAsync() {
+  const removePrevious = `docker kill ${CONTAINER_NAME}`;
+
+  try {
+    await execPromise(removePrevious);
+  } catch (error) {
+    console.error(error);
+    throw new Error("Failed to remove docker container");
+  }
+}
+
+async function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitForChainToStart(url) {
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    try {
+      const client = new JsonRpcProvider(url);
+      console.log(`connecting to ${url}...`);
+      const networkId = await client.getNetwork();
+      return Number(networkId.chainId);
+    } catch (e) {
+      console.log(`client not ready`);
+    }
+    await sleep(250);
+  }
+}
+
+export async function mochaGlobalSetup() {
+  if (process.env.SKIP_LOCAL_ENV === "true") {
+    return;
+  }
+
+  runDockerContainerAsync();
+
+  console.log("\nWaiting for Fhenix to start...");
+
+  await waitForChainToStart(TEST_ENDPOINT_URL);
+
+  console.log("Fhenix is running!");
+}
+
+// this is a cjs because jest sucks at typescript
+
+export async function mochaGlobalTeardown() {
+  if (process.env.SKIP_LOCAL_ENV === "true") {
+    return;
+  }
+  console.log("\nWaiting for Fhenix to stop...");
+
+  await killDockerContainerAsync();
+
+  console.log("Stopped test container. Goodbye!");
+}

--- a/packages/fhenix-hardhat-plugin/package.json
+++ b/packages/fhenix-hardhat-plugin/package.json
@@ -17,7 +17,7 @@
   ],
   "scripts": {
     "lint": "eslint --config ./.eslintrc.json --ignore-path ./.eslintignore ./**/*.ts",
-    "test": "mocha --exit --recursive --timeout 60000 'test/*.test.ts'",
+    "test": "mocha --exit --recursive --timeout 60000 --require 'mocha-fixtures.mjs' 'test/*.test.ts'",
     "build": "tsc",
     "watch": "tsc -w",
     "prepublishOnly": "npm run build"

--- a/packages/fhenix-hardhat-plugin/package.json
+++ b/packages/fhenix-hardhat-plugin/package.json
@@ -53,7 +53,7 @@
     "chalk": "^4.1.2",
     "ethers": "^6.10.0",
     "fast-glob": "^3.3.2",
-    "fhenixjs": "^0.4.2-alpha.1"
+    "fhenixjs": "^0.4.2-alpha.2"
   },
   "peerDependencies": {
     "hardhat": "^2.11.0"

--- a/packages/fhenix-hardhat-plugin/src/index.ts
+++ b/packages/fhenix-hardhat-plugin/src/index.ts
@@ -102,7 +102,7 @@ task(TASK_FHENIX_USE_FAUCET, "Fund an account from the faucet")
   .addOptionalParam(
     "url",
     "Optional Faucet URL",
-    "http://localhost:42000",
+    "http://localhost:3000",
     types.string,
   )
   .setAction(

--- a/packages/fhenix-hardhat-plugin/src/index.ts
+++ b/packages/fhenix-hardhat-plugin/src/index.ts
@@ -1,5 +1,5 @@
 import chalk from "chalk";
-import { HDNodeWallet, Wallet } from "ethers";
+import { HDNodeWallet, TypedDataField, Wallet } from "ethers";
 import { TASK_COMPILE_SOLIDITY_EMIT_ARTIFACTS } from "hardhat/builtin-tasks/task-names";
 import { extendConfig, extendEnvironment, task, types } from "hardhat/config";
 import { lazyObject } from "hardhat/plugins";
@@ -42,20 +42,32 @@ extendEnvironment((hre) => {
 
   hre.fhenixsdk = lazyObject(() => ({
     ...fhenixsdk,
-    initializeWithHHSigner: async ({ signer, ...params }) => {
-      fhenixsdk.initialize({
+    initializeWithHHSigner: async ({ signer, ...params }) =>
+      hre.fhenixsdk.initialize({
         provider: {
-          call: signer.provider.call,
+          call: async (...args) => {
+            try {
+              return signer.provider.call(...args);
+            } catch (e) {
+              throw new Error(
+                `fhenixsdk initializeWithHHSigner :: call :: ${e}`,
+              );
+            }
+          },
           getChainId: async () =>
             (await signer.provider.getNetwork()).chainId.toString(),
         },
         signer: {
-          signTypedData: signer.signTypedData,
-          getAddress: signer.getAddress,
+          signTypedData: async (domain, types, value) =>
+            signer.signTypedData(
+              domain,
+              types as Record<string, TypedDataField[]>,
+              value,
+            ),
+          getAddress: async () => signer.getAddress(),
         },
         ...params,
-      });
-    },
+      }),
   }));
 });
 

--- a/packages/fhenix-hardhat-plugin/src/type-extensions.ts
+++ b/packages/fhenix-hardhat-plugin/src/type-extensions.ts
@@ -26,6 +26,8 @@ type FhenixsdkInitWithHHSignerParams = Expand<
 > &
   PermitV2AccessRequirementsParams;
 
+type FhenixsdkInitReturnType = ReturnType<typeof fhenixsdk["initialize"]>;
+
 declare module "hardhat/types/runtime" {
   // Fhenix extension to the Hardhat Runtime Environment.
   // This new field will be available in tasks' actions, scripts, and tests.
@@ -37,7 +39,7 @@ declare module "hardhat/types/runtime" {
        */
       initializeWithHHSigner: (
         params: FhenixsdkInitWithHHSignerParams,
-      ) => Promise<void>;
+      ) => FhenixsdkInitReturnType;
     };
   }
 }

--- a/packages/fhenix-hardhat-plugin/test/project.test.ts
+++ b/packages/fhenix-hardhat-plugin/test/project.test.ts
@@ -66,7 +66,11 @@ describe("Test Fhenix Plugin", function () {
       expect(bobPermit).to.be.an("object");
     });
     it("fhenixsdk encrypt", function () {
-      const fakeEnc = this.hre.fhenixsdk.encrypt(Encryptable.uint8(5));
+      const fakeEncResult = this.hre.fhenixsdk.encrypt(Encryptable.uint8(5));
+      expect(fakeEncResult.success).to.be.equal(true);
+      if (!fakeEncResult.success) return;
+
+      const fakeEnc = fakeEncResult.data;
       expect(fakeEnc).to.be.an("object");
       expect(fakeEnc).to.have.property("data");
       expect(fakeEnc).to.have.property("securityZone");
@@ -83,15 +87,18 @@ describe("Test Fhenix Plugin", function () {
       const bobSigner = await bobProvider.getSigner();
 
       // Should initialize correctly, but fhe public key for hardhat not set
-      await this.hre.fhenixsdk.initialize({
+      // Should create and return a permit as a Result object
+      const bobPermitResult = await this.hre.fhenixsdk.initialize({
         provider: bobProvider,
         signer: bobSigner,
         projects: ["TEST"],
       });
+      expect(bobPermitResult.success).to.equal(true);
+      if (!bobPermitResult.success) return;
 
-      // Should create a permit
-      const bobPermit = await this.hre.fhenixsdk.createPermit();
+      const bobPermit = bobPermitResult.data;
       expect(bobPermit).to.be.an("object");
+      if (bobPermit == null) return;
 
       // Active hash should match
       const activeHash = this.hre.fhenixsdk.getPermit()?.data?.getHash();
@@ -129,14 +136,19 @@ describe("Test Fhenix Plugin", function () {
     });
     it("fhenixsdk.initializeWithHHSigner utility function", async function () {
       const [signer] = await this.hre.ethers.getSigners();
-      await this.hre.fhenixsdk.initializeWithHHSigner({
+      const permitResult = await this.hre.fhenixsdk.initializeWithHHSigner({
         signer,
         projects: ["TEST"],
       });
 
+      // Initialization creates a permit
+      expect(permitResult.data == null).to.equal(false);
+      expect(permitResult.data).to.be.an("object");
+
       // Should create a permit
-      const bobPermit = await this.hre.fhenixsdk.createPermit();
-      expect(bobPermit).to.be.an("object");
+      const bobPermitResult = await this.hre.fhenixsdk.createPermit();
+      expect(bobPermitResult.data == null).to.equal(false);
+      expect(bobPermitResult.data).to.be.an("object");
     });
   });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -162,8 +162,8 @@ importers:
         specifier: ^3.3.2
         version: 3.3.2
       fhenixjs:
-        specifier: ^0.4.2-alpha.1
-        version: 0.4.2-alpha.1
+        specifier: ^0.4.2-alpha.2
+        version: 0.4.2-alpha.2
     devDependencies:
       '@nomicfoundation/hardhat-ethers':
         specifier: ^3.0.5
@@ -1336,8 +1336,8 @@ packages:
   fastq@1.17.1:
     resolution: {integrity: sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==}
 
-  fhenixjs@0.4.2-alpha.1:
-    resolution: {integrity: sha512-4q4jSmlWpc0mswhBJqvjYJ6aSpGlZbgk3izgtD7znTzweZKniK+CRUm+Qcc+jLM3r3VsLWlyhc+fgDSISrKUHQ==}
+  fhenixjs@0.4.2-alpha.2:
+    resolution: {integrity: sha512-BhJ5xpnM3zsc6kPcol4ZKVB0Gcm10wEswCSNA8iaHzHy9glWnRMD/GwmfUmduLQjzbZDmUfHVvficjGlEpLHrQ==}
     engines: {node: '>=20.0.0'}
 
   file-entry-cache@6.0.1:
@@ -4015,7 +4015,7 @@ snapshots:
     dependencies:
       reusify: 1.0.4
 
-  fhenixjs@0.4.2-alpha.1:
+  fhenixjs@0.4.2-alpha.2:
     dependencies:
       '@types/node': 20.16.1
       immer: 10.1.1


### PR DESCRIPTION
- References correct fhenixsdk instance
- Returns the result of the `initialization` permit as a `Result` object
- Handles errors correctly